### PR TITLE
Remove unnecessary restriction on status card images

### DIFF
--- a/site-settings/custom-css.css
+++ b/site-settings/custom-css.css
@@ -1005,8 +1005,6 @@ a.status-card:hover {
 }
 
 .status-card__image-image {
-  height: 60px;
-  width: 60px;
   border-radius: 0px 0px 0px 0px !important;
 }
 


### PR DESCRIPTION
From what I can tell, these hard coded width and height only affect the thumbnail on the main feed by 1px, however, they totally screw up the preview on the main profile page. See #56 for details about what I mean.

Here is example of the main profile page with the fix.
![image](https://user-images.githubusercontent.com/13974112/62572157-61154d00-b893-11e9-88af-4619de3c89ff.png)

and here is an image of what the main feed looks like with the fix (you wouldn't be able to tell the difference unless you saw them side by side).

![image](https://user-images.githubusercontent.com/13974112/62572226-830ecf80-b893-11e9-999a-1a6947875b28.png)
