### PR TITLE
fix reply button margin

### DIFF
--- a/site-settings/custom-css.css
+++ b/site-settings/custom-css.css
@@ -794,7 +794,6 @@ a.status-card:hover {
 .icon-button i.fa-reply-all {
   background-image: url("data:image/svg+xml; utf8,<svg xmlns='http://www.w3.org/2000/svg' width='22' height='22'><path d='M11,4 L18,11 L11,18 L4,11 Z' stroke='%23555' fill='none' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/></svg>");
   display: inline-block;
-  margin-top: 3px;
 }
 
 .icon-button i.fa-reply:hover,


### PR DESCRIPTION
following the recent fix on the buttons margins,
i thought something was off in the post view.. and it was

before: 
![before--20190809-121836](https://user-images.githubusercontent.com/39516339/62773068-81b2f200-baa1-11e9-969e-cc6d215de7c4.png)

after:
![after--20190809-122648](https://user-images.githubusercontent.com/39516339/62773080-85df0f80-baa1-11e9-97a6-70f6ece03b34.png)
