### PR TITLE
Hide reply count

### DIFF
--- a/site-settings/merveilles-theme/merveilles.scss
+++ b/site-settings/merveilles-theme/merveilles.scss
@@ -286,6 +286,10 @@ body {
   background-color: rgba(0,0,0,0);
 }
 
+.icon-button__counter {
+  display: none;
+}
+
 .compose-form__sensitive-button .icon-button {
     color: var(--gray-shade-3)!important;
 }


### PR DESCRIPTION
I feel the reply counter is an unnecessary feature. In the spirit of "slow social media" we should hide it.
By hiding the reply count, the reply icon has more room and is no longer cut off in the web UI.

<details>
<summary>Click to view screenshots</summary>

### Before

<img width="92" alt="Screen Shot 2020-12-28 at 9 16 15 AM" src="https://user-images.githubusercontent.com/3891632/103220141-82923100-48ed-11eb-8d6a-d72c180e7386.png">


### After

<img width="105" alt="Screen Shot 2020-12-28 at 9 16 03 AM" src="https://user-images.githubusercontent.com/3891632/103220142-858d2180-48ed-11eb-94bd-7cd074c80177.png">


</details>